### PR TITLE
Add integrated party and raid group frames with Edit Mode, preview, and options

### DIFF
--- a/MidnightSimpleUnitFrames/Core/MSUF_GroupFrames.lua
+++ b/MidnightSimpleUnitFrames/Core/MSUF_GroupFrames.lua
@@ -1,0 +1,302 @@
+local addonName, ns = ...
+
+local Roster = ns.GroupRoster or _G.MSUF_GroupRoster
+local Update = ns.GroupUpdate or _G.MSUF_GroupUpdate
+if not (Roster and Update) then return end
+
+local GroupFrames = {}
+ns.GroupFrames = GroupFrames
+_G.MSUF_GroupFrames = GroupFrames
+
+local containers = {}
+local ClickCastFrames = _G.ClickCastFrames or {}
+_G.ClickCastFrames = ClickCastFrames
+local KINDS = { "party", "raid" }
+local MAX_BUTTONS = { party = 5, raid = 40 }
+local DEFAULTS = {
+    party = { width = 132, height = 28, spacingX = 0, spacingY = 4, columns = 1, maxFrames = 5, offsetX = 420, offsetY = -260 },
+    raid  = { width = 92, height = 22, spacingX = 4, spacingY = 4, columns = 5, maxFrames = 40, offsetX = 420, offsetY = -24 },
+}
+
+local function GetDB(kind)
+    local db = _G.MSUF_DB
+    if not db and type(_G.EnsureDB) == "function" then
+        _G.EnsureDB()
+        db = _G.MSUF_DB
+    end
+    if not db then
+        _G.MSUF_DB = _G.MSUF_DB or {}
+        db = _G.MSUF_DB
+    end
+    db.groupFrames = db.groupFrames or {}
+    db.groupFrames[kind] = db.groupFrames[kind] or {}
+    local conf = db.groupFrames[kind]
+    local def = DEFAULTS[kind]
+    for k, v in pairs(def) do
+        if conf[k] == nil then conf[k] = v end
+    end
+    if conf.enabled == nil then conf.enabled = true end
+    if conf.showInEditMode == nil then conf.showInEditMode = true end
+    if conf.growDown == nil then conf.growDown = true end
+    return conf
+end
+
+local function IsEditMode()
+    return (_G.MSUF_EM2 and _G.MSUF_EM2.State and _G.MSUF_EM2.State.IsActive and _G.MSUF_EM2.State.IsActive())
+        or (_G.MSUF_UnitEditModeActive and true or false)
+end
+
+local function IsPreviewActive(kind)
+    return Roster.GetPreviewMode and Roster.GetPreviewMode() == kind
+end
+
+local function ShouldShow(kind, unitCount)
+    local conf = GetDB(kind)
+    if conf.enabled == false then return false end
+    if IsPreviewActive(kind) then return true end
+    if kind == "party" then
+        if IsInRaid and IsInRaid() then return false end
+        if unitCount > 0 then return true end
+    elseif kind == "raid" then
+        if IsInRaid and IsInRaid() and unitCount > 0 then return true end
+    end
+    if IsEditMode() and conf.showInEditMode then return true end
+    return false
+end
+
+local function ApplyContainerPoint(holder, conf)
+    holder:ClearAllPoints()
+    holder:SetPoint(conf.point or "TOPLEFT", UIParent, conf.relPoint or conf.point or "TOPLEFT", conf.offsetX or 0, conf.offsetY or 0)
+end
+
+local function CreateButton(parent, kind, index)
+    local btn = CreateFrame("Button", "MSUF_Group_" .. kind .. index, parent, "BackdropTemplate,SecureUnitButtonTemplate,PingableUnitFrameTemplate")
+    btn.kind = kind
+    btn.index = index
+    btn:SetClampedToScreen(true)
+    btn:RegisterForClicks("AnyUp")
+    btn:SetAttribute("*type1", "target")
+    btn:SetAttribute("*type2", "togglemenu")
+
+    btn.bg = btn:CreateTexture(nil, "BACKGROUND")
+    btn.bg:SetAllPoints()
+
+    btn.hpBar = CreateFrame("StatusBar", nil, btn)
+    btn.hpBar:SetPoint("TOPLEFT", btn, "TOPLEFT", 1, -1)
+    btn.hpBar:SetPoint("BOTTOMRIGHT", btn, "BOTTOMRIGHT", -1, 1)
+    btn.hpBar:SetMinMaxValues(0, 1)
+
+    btn.powerBar = CreateFrame("StatusBar", nil, btn)
+    btn.powerBar:SetPoint("TOPLEFT", btn.hpBar, "BOTTOMLEFT", 0, 0)
+    btn.powerBar:SetPoint("TOPRIGHT", btn.hpBar, "BOTTOMRIGHT", 0, 0)
+    btn.powerBar:SetHeight(3)
+    btn.powerBar:SetMinMaxValues(0, 1)
+    btn.powerBar:SetStatusBarColor(0.15, 0.45, 0.88, 1)
+
+    btn.nameText = btn:CreateFontString(nil, "OVERLAY", "GameFontHighlightSmall")
+    btn.nameText:SetPoint("LEFT", btn, "LEFT", 6, 0)
+    btn.nameText:SetPoint("RIGHT", btn, "RIGHT", -6, 0)
+    btn.nameText:SetJustifyH("LEFT")
+
+    btn.statusText = btn:CreateFontString(nil, "OVERLAY", "GameFontDisableSmall")
+    btn.statusText:SetPoint("RIGHT", btn, "RIGHT", -6, 0)
+    btn.statusText:SetJustifyH("RIGHT")
+    btn.statusText:Hide()
+
+    btn.unitLabel = btn:CreateFontString(nil, "OVERLAY", "GameFontDisableTiny")
+    btn.unitLabel:SetPoint("TOPRIGHT", btn, "TOPRIGHT", -4, -3)
+    btn.unitLabel:SetTextColor(1, 0.82, 0, 0.8)
+    btn.unitLabel:Hide()
+
+    btn.border = CreateFrame("Frame", nil, btn, "BackdropTemplate")
+    btn.border:SetAllPoints()
+    btn.border:SetBackdrop({ edgeFile = "Interface\\Buttons\\WHITE8X8", edgeSize = 1 })
+
+    btn:SetScript("OnEnter", function(self)
+        if self.border and self.border.SetBackdropBorderColor then
+            self.border:SetBackdropBorderColor(1, 0.82, 0, 0.65)
+        end
+    end)
+    btn:SetScript("OnLeave", function(self)
+        if self.border and self.border.SetBackdropBorderColor then
+            self.border:SetBackdropBorderColor(0.10, 0.20, 0.42, 0.35)
+        end
+    end)
+
+    ClickCastFrames[btn] = true
+    return btn
+end
+
+local function EnsureContainer(kind)
+    if containers[kind] then return containers[kind] end
+    local holder = CreateFrame("Frame", "MSUF_GroupHolder_" .. kind, UIParent, "BackdropTemplate")
+    holder.kind = kind
+    holder.buttons = {}
+    holder.label = holder:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
+    holder.label:SetPoint("BOTTOMLEFT", holder, "TOPLEFT", 0, 4)
+    holder.label:SetText(kind == "party" and "MSUF Party" or "MSUF Raid")
+    holder.label:SetTextColor(1, 0.82, 0, 0.95)
+    holder.bg = holder:CreateTexture(nil, "BACKGROUND")
+    holder.bg:SetAllPoints()
+    holder.bg:SetColorTexture(0.03, 0.05, 0.12, 0.08)
+    holder.border = CreateFrame("Frame", nil, holder, "BackdropTemplate")
+    holder.border:SetAllPoints()
+    holder.border:SetBackdrop({ edgeFile = "Interface\\Buttons\\WHITE8X8", edgeSize = 1 })
+    holder.border:SetBackdropBorderColor(0.10, 0.20, 0.45, 0.30)
+
+    for i = 1, MAX_BUTTONS[kind] do
+        holder.buttons[i] = CreateButton(holder, kind, i)
+    end
+
+    containers[kind] = holder
+    return holder
+end
+
+local function LayoutContainer(kind)
+    local holder = EnsureContainer(kind)
+    local conf = GetDB(kind)
+    local cols = math.max(1, tonumber(conf.columns) or 1)
+    local width = tonumber(conf.width) or DEFAULTS[kind].width
+    local height = tonumber(conf.height) or DEFAULTS[kind].height
+    local sx = tonumber(conf.spacingX) or 0
+    local sy = tonumber(conf.spacingY) or 0
+    local maxFrames = math.min(MAX_BUTTONS[kind], tonumber(conf.maxFrames) or MAX_BUTTONS[kind])
+    local shown = 0
+
+    for i = 1, MAX_BUTTONS[kind] do
+        local btn = holder.buttons[i]
+        btn:SetSize(width, height)
+        btn.powerBar:SetHeight(kind == "party" and 3 or 2)
+        if i <= maxFrames then
+            local row = math.floor((i - 1) / cols)
+            local col = (i - 1) % cols
+            local x = col * (width + sx)
+            local y = -row * (height + sy)
+            btn:ClearAllPoints()
+            btn:SetPoint("TOPLEFT", holder, "TOPLEFT", x, y)
+            shown = i
+        else
+            btn:Hide()
+        end
+    end
+
+    local rows = math.max(1, math.ceil(maxFrames / cols))
+    holder:SetSize((math.min(cols, maxFrames) * width) + (math.max(0, math.min(cols, maxFrames) - 1) * sx), (rows * height) + (math.max(0, rows - 1) * sy))
+    ApplyContainerPoint(holder, conf)
+    return shown
+end
+
+local function BindButtonUnit(button, unit)
+    Roster.ClearButtonMap(button)
+    button.unit = unit
+    if unit and not unit:match("^preview_") then
+        button:SetAttribute("unit", unit)
+        Roster.RegisterButton(unit, button)
+    else
+        button:SetAttribute("unit", nil)
+    end
+end
+
+local function RefreshKind(kind)
+    local holder = EnsureContainer(kind)
+    local conf = GetDB(kind)
+    local units = Roster.GetUnits(kind)
+    local maxFrames = math.min(MAX_BUTTONS[kind], tonumber(conf.maxFrames) or MAX_BUTTONS[kind])
+    LayoutContainer(kind)
+
+    for i = 1, MAX_BUTTONS[kind] do
+        local btn = holder.buttons[i]
+        local unit = units[i]
+        if unit and i <= maxFrames then
+            BindButtonUnit(btn, unit)
+            Update.ApplyUnit(btn, unit, kind, i)
+            btn:Show()
+        elseif IsEditMode() and conf.showInEditMode and i <= math.min(maxFrames, kind == "party" and 5 or 20) then
+            local previewUnit = (kind == "party" and "preview_party" or "preview_raid") .. i
+            BindButtonUnit(btn, previewUnit)
+            Update.ApplyUnit(btn, previewUnit, kind, i)
+            btn:Show()
+        else
+            BindButtonUnit(btn, nil)
+            btn:Hide()
+        end
+    end
+
+    holder.label:SetShown(IsEditMode() or IsPreviewActive(kind))
+    holder:SetShown(ShouldShow(kind, #units))
+end
+
+function GroupFrames.Refresh(kind)
+    if kind then
+        RefreshKind(kind)
+        return
+    end
+    for i = 1, #KINDS do RefreshKind(KINDS[i]) end
+end
+
+function GroupFrames.ApplyStyle(kind)
+    if kind then
+        local holder = EnsureContainer(kind)
+        for i = 1, #holder.buttons do
+            Update.ApplySharedStyle(holder.buttons[i], kind)
+        end
+        RefreshKind(kind)
+        return
+    end
+    for i = 1, #KINDS do GroupFrames.ApplyStyle(KINDS[i]) end
+end
+
+function GroupFrames.GetContainer(kind)
+    return EnsureContainer(kind)
+end
+
+function GroupFrames.GetConfig(kind)
+    return GetDB(kind)
+end
+
+function GroupFrames.SetPreviewMode(mode)
+    if Roster and Roster.SetPreviewMode then
+        Roster.SetPreviewMode(mode)
+    end
+end
+
+function GroupFrames.GetPreviewMode()
+    return Roster and Roster.GetPreviewMode and Roster.GetPreviewMode() or nil
+end
+
+function GroupFrames.TryEnable()
+    EnsureContainer("party")
+    EnsureContainer("raid")
+    GroupFrames.Refresh()
+end
+
+Roster.RegisterListener(function(event, payload)
+    if event == "unit" and payload then
+        local buttons = Roster.IterButtons(payload)
+        if buttons then
+            for i = 1, #buttons do
+                local btn = buttons[i]
+                if btn and btn:IsShown() then
+                    Update.ApplyUnit(btn, payload, btn.kind, btn.index)
+                end
+            end
+        end
+        return
+    end
+    GroupFrames.Refresh()
+end)
+
+C_Timer.After(0, function()
+    GroupFrames.TryEnable()
+    if hooksecurefunc then
+        if type(_G.MSUF_UpdateAllFonts) == "function" then
+            hooksecurefunc(_G, "MSUF_UpdateAllFonts", function() GroupFrames.ApplyStyle() end)
+        end
+        if type(_G.MSUF_RefreshAllIdentityColors) == "function" then
+            hooksecurefunc(_G, "MSUF_RefreshAllIdentityColors", function() GroupFrames.ApplyStyle() end)
+        end
+        if type(_G.ApplyAllSettings) == "function" then
+            hooksecurefunc(_G, "ApplyAllSettings", function() GroupFrames.Refresh() end)
+        end
+    end
+end)

--- a/MidnightSimpleUnitFrames/Core/MSUF_GroupRoster.lua
+++ b/MidnightSimpleUnitFrames/Core/MSUF_GroupRoster.lua
@@ -1,0 +1,202 @@
+local addonName, ns = ...
+
+local Roster = {}
+ns.GroupRoster = Roster
+_G.MSUF_GroupRoster = Roster
+
+local listeners = {}
+local activeUnits = {}
+local unitToButtons = {}
+local previewMode = nil
+local unitEventFrame
+local rosterFrame
+
+local PARTY_UNITS = { "player", "party1", "party2", "party3", "party4" }
+local RAID_LIMIT = 40
+
+local function CopyList(src, dest)
+    dest = dest or {}
+    for i = 1, #src do dest[i] = src[i] end
+    for i = #src + 1, #dest do dest[i] = nil end
+    return dest
+end
+
+local function GetDB()
+    local db = _G.MSUF_DB
+    if not db and type(_G.EnsureDB) == "function" then
+        _G.EnsureDB()
+        db = _G.MSUF_DB
+    end
+    return db
+end
+
+local function GetPreviewUnits(kind)
+    local out = {}
+    if kind == "party" then
+        for i = 1, 5 do
+            out[i] = "preview_party" .. i
+        end
+    else
+        for i = 1, 20 do
+            out[i] = "preview_raid" .. i
+        end
+    end
+    return out
+end
+
+local function BuildPartyUnits()
+    local out = {}
+    local count = 0
+    if IsInRaid and IsInRaid() then return out end
+    local members = (GetNumGroupMembers and GetNumGroupMembers()) or 0
+    if members <= 0 then return out end
+    for i = 1, #PARTY_UNITS do
+        local unit = PARTY_UNITS[i]
+        if UnitExists and UnitExists(unit) then
+            count = count + 1
+            out[count] = unit
+        end
+    end
+    return out
+end
+
+local function BuildRaidUnits(maxCount)
+    local out = {}
+    if not (IsInRaid and IsInRaid()) then return out end
+    local members = (GetNumGroupMembers and GetNumGroupMembers()) or 0
+    if members <= 0 then return out end
+    local limit = math.min(maxCount or RAID_LIMIT, members, RAID_LIMIT)
+    for i = 1, limit do
+        out[i] = "raid" .. i
+    end
+    return out
+end
+
+local function RebuildActiveUnits()
+    for unit in pairs(activeUnits) do activeUnits[unit] = nil end
+
+    local party = Roster.GetUnits("party")
+    for i = 1, #party do activeUnits[party[i]] = true end
+
+    local raid = Roster.GetUnits("raid")
+    for i = 1, #raid do activeUnits[raid[i]] = true end
+end
+
+local function RegisterUnitEvents()
+    if not unitEventFrame then return end
+    unitEventFrame:UnregisterAllEvents()
+    for unit in pairs(activeUnits) do
+        unitEventFrame:RegisterUnitEvent("UNIT_HEALTH", unit)
+        unitEventFrame:RegisterUnitEvent("UNIT_MAXHEALTH", unit)
+        unitEventFrame:RegisterUnitEvent("UNIT_NAME_UPDATE", unit)
+        unitEventFrame:RegisterUnitEvent("UNIT_CONNECTION", unit)
+        unitEventFrame:RegisterUnitEvent("UNIT_FLAGS", unit)
+        unitEventFrame:RegisterUnitEvent("UNIT_DISPLAYPOWER", unit)
+    end
+end
+
+local function Notify(event, payload)
+    for i = 1, #listeners do
+        local fn = listeners[i]
+        if type(fn) == "function" then
+            pcall(fn, event, payload)
+        end
+    end
+end
+
+function Roster.RegisterListener(fn)
+    if type(fn) ~= "function" then return end
+    listeners[#listeners + 1] = fn
+end
+
+function Roster.SetPreviewMode(mode)
+    if mode ~= "party" and mode ~= "raid" then mode = nil end
+    if previewMode == mode then return end
+    previewMode = mode
+    RebuildActiveUnits()
+    RegisterUnitEvents()
+    Notify("preview", mode)
+    Notify("roster")
+end
+
+function Roster.GetPreviewMode()
+    return previewMode
+end
+
+function Roster.GetUnits(kind)
+    if previewMode == kind then
+        return GetPreviewUnits(kind)
+    end
+    if kind == "party" then
+        return BuildPartyUnits()
+    end
+    local db = GetDB()
+    local gf = db and db.groupFrames and db.groupFrames.raid
+    local maxCount = (gf and gf.maxFrames) or RAID_LIMIT
+    return BuildRaidUnits(maxCount)
+end
+
+function Roster.RegisterButton(unit, button)
+    if not unit or not button then return end
+    local list = unitToButtons[unit]
+    if not list then
+        list = {}
+        unitToButtons[unit] = list
+    end
+    list[#list + 1] = button
+end
+
+function Roster.ClearButtonMap(button)
+    for unit, list in pairs(unitToButtons) do
+        local n = 0
+        for i = 1, #list do
+            if list[i] ~= button then
+                n = n + 1
+                list[n] = list[i]
+            end
+        end
+        for i = n + 1, #list do list[i] = nil end
+        if n == 0 then unitToButtons[unit] = nil end
+    end
+end
+
+function Roster.IterButtons(unit)
+    return unitToButtons[unit]
+end
+
+function Roster.Refresh()
+    RebuildActiveUnits()
+    RegisterUnitEvents()
+    Notify("roster")
+end
+
+local function OnUnitEvent(_, event, unit)
+    local buttons = unit and unitToButtons[unit]
+    if buttons and #buttons > 0 then
+        Notify("unit", unit)
+    else
+        Notify("unit", unit)
+    end
+end
+
+local function OnRosterEvent(_, event)
+    if event == "PLAYER_LOGIN" then
+        rosterFrame:UnregisterEvent("PLAYER_LOGIN")
+    end
+    Roster.Refresh()
+end
+
+function Roster.Ensure()
+    if rosterFrame then return end
+
+    rosterFrame = CreateFrame("Frame", "MSUF_GroupRosterFrame")
+    rosterFrame:RegisterEvent("PLAYER_LOGIN")
+    rosterFrame:RegisterEvent("PLAYER_ENTERING_WORLD")
+    rosterFrame:RegisterEvent("GROUP_ROSTER_UPDATE")
+    rosterFrame:SetScript("OnEvent", OnRosterEvent)
+
+    unitEventFrame = CreateFrame("Frame", "MSUF_GroupRosterUnitFrame")
+    unitEventFrame:SetScript("OnEvent", OnUnitEvent)
+end
+
+Roster.Ensure()

--- a/MidnightSimpleUnitFrames/Core/MSUF_GroupUpdate.lua
+++ b/MidnightSimpleUnitFrames/Core/MSUF_GroupUpdate.lua
@@ -1,0 +1,218 @@
+local addonName, ns = ...
+
+local Update = {}
+ns.GroupUpdate = Update
+_G.MSUF_GroupUpdate = Update
+
+local UnitHealthPercent = UnitHealthPercent
+local UnitClass = UnitClass
+local UnitName = UnitName
+local UnitIsConnected = UnitIsConnected
+local UnitIsDeadOrGhost = UnitIsDeadOrGhost
+local UnitPowerPercent = UnitPowerPercent
+
+local PREVIEW_CLASS = { "PRIEST", "WARRIOR", "MAGE", "DRUID", "PALADIN", "SHAMAN", "ROGUE", "WARLOCK", "HUNTER", "MONK" }
+
+local function GetDB(kind)
+    local db = _G.MSUF_DB
+    local gf = db and db.groupFrames
+    return gf and gf[kind]
+end
+
+local function GetFontPath(conf)
+    if conf and conf.fontOverride and conf.fontPath and conf.fontPath ~= "" then
+        return conf.fontPath
+    end
+    if ns and ns.Castbars and type(ns.Castbars._GetFontPath) == "function" then
+        return ns.Castbars._GetFontPath()
+    end
+    return STANDARD_TEXT_FONT or "Fonts/FRIZQT__.TTF"
+end
+
+local function GetFontFlags()
+    if ns and ns.Castbars and type(ns.Castbars._GetFontFlags) == "function" then
+        return ns.Castbars._GetFontFlags()
+    end
+    return ""
+end
+
+local function GetBaseFontColor()
+    if type(_G.MSUF_GetConfiguredFontColor) == "function" then
+        return _G.MSUF_GetConfiguredFontColor()
+    end
+    return 1, 1, 1
+end
+
+local function GetPreviewInfo(kind, index)
+    local classes = PREVIEW_CLASS
+    local classToken = classes[((index - 1) % #classes) + 1]
+    local name = (kind == "party" and "Party" or "Raid") .. " " .. tostring(index)
+    local hp = kind == "party" and (0.86 - (index - 1) * 0.09) or (0.96 - ((index - 1) % 5) * 0.12)
+    local power = kind == "party" and (0.40 + (index - 1) * 0.08) or (0.25 + ((index - 1) % 4) * 0.14)
+    if hp < 0.18 then hp = 0.18 end
+    if power > 1 then power = 1 end
+    return {
+        name = name,
+        classToken = classToken,
+        health = hp,
+        power = power,
+        connected = true,
+        dead = false,
+        offline = false,
+    }
+end
+
+local function ResolveClassColor(classToken)
+    if ns and ns._colorsAPI and type(ns._colorsAPI.GetClassColor) == "function" then
+        local r, g, b = ns._colorsAPI.GetClassColor(classToken)
+        if r ~= nil then return r, g, b end
+    end
+    if C_ClassColor and C_ClassColor.GetClassColor then
+        local color = C_ClassColor.GetClassColor(classToken)
+        if color and color.GetRGB then return color:GetRGB() end
+    end
+    local tbl = RAID_CLASS_COLORS and RAID_CLASS_COLORS[classToken]
+    if tbl then return tbl.r, tbl.g, tbl.b end
+    return 0.35, 0.35, 0.38
+end
+
+local function ResolveFillColor(conf, classToken)
+    if conf and conf.colorOverride then
+        if conf.useClassColors then
+            return ResolveClassColor(classToken)
+        end
+        if conf.darkMode then
+            return 0.22, 0.24, 0.28
+        end
+        return conf.colorR or 0.18, conf.colorG or 0.55, conf.colorB or 0.88
+    end
+    local db = _G.MSUF_DB
+    local g = db and db.general
+    if g and g.useClassColors then
+        return ResolveClassColor(classToken)
+    end
+    if g and g.darkMode then
+        return 0.22, 0.24, 0.28
+    end
+    return ResolveClassColor(classToken)
+end
+
+local function ResolveBarTexture(conf)
+    if conf and conf.barOverride and conf.barTexture and conf.barTexture ~= "" then
+        return conf.barTexture
+    end
+    if type(_G.MSUF_GetBarTexture) == "function" then
+        return _G.MSUF_GetBarTexture()
+    end
+    return "Interface\\Buttons\\WHITE8X8"
+end
+
+function Update.ApplySharedStyle(button, kind)
+    if not button then return end
+    local conf = GetDB(kind)
+    local fontPath = GetFontPath(conf)
+    local flags = GetFontFlags()
+    local fr, fg, fb = GetBaseFontColor()
+    local nameSize = (conf and conf.nameFontSize) or 11
+    local statusSize = math.max(9, nameSize - 1)
+    local texture = ResolveBarTexture(conf)
+
+    if button.hpBar and button.hpBar.SetStatusBarTexture then
+        button.hpBar:SetStatusBarTexture(texture)
+    end
+    if button.powerBar and button.powerBar.SetStatusBarTexture then
+        button.powerBar:SetStatusBarTexture(texture)
+    end
+    if button.nameText and button.nameText.SetFont then
+        button.nameText:SetFont(fontPath, nameSize, flags)
+        button.nameText:SetTextColor(fr, fg, fb, 1)
+    end
+    if button.statusText and button.statusText.SetFont then
+        button.statusText:SetFont(fontPath, statusSize, flags)
+        button.statusText:SetTextColor(fr, fg, fb, 0.9)
+    end
+end
+
+function Update.ApplyUnit(button, unit, kind, index)
+    if not button then return end
+    local conf = GetDB(kind)
+    local preview = unit and unit:match("^preview_") and true or false
+    local info
+
+    if preview then
+        info = GetPreviewInfo(kind, index)
+    else
+        local _, classToken = UnitClass(unit)
+        local hp = UnitHealthPercent and UnitHealthPercent(unit, true) or 0
+        local power = UnitPowerPercent and UnitPowerPercent(unit, true) or 0
+        local connected = UnitIsConnected and UnitIsConnected(unit)
+        local dead = UnitIsDeadOrGhost and UnitIsDeadOrGhost(unit)
+        local nm = UnitName and UnitName(unit)
+        info = {
+            name = nm or unit,
+            classToken = classToken,
+            health = hp or 0,
+            power = power or 0,
+            connected = connected ~= false,
+            dead = dead and true or false,
+            offline = connected == false,
+        }
+    end
+
+    Update.ApplySharedStyle(button, kind)
+
+    local r, g, b = ResolveFillColor(conf, info.classToken)
+    local text = info.name or "Unknown"
+    local alpha = info.offline and 0.45 or 1
+    local status = ""
+
+    if info.dead then
+        status = DEAD or "Dead"
+        alpha = 0.55
+    elseif info.offline then
+        status = PLAYER_OFFLINE or "Offline"
+        alpha = 0.45
+    end
+
+    if button.hpBar then
+        if type(_G.MSUF_SetBarValue) == "function" then
+            _G.MSUF_SetBarValue(button.hpBar, info.health or 0, false)
+        else
+            button.hpBar:SetValue(info.health or 0)
+        end
+        button.hpBar:SetStatusBarColor(r, g, b, alpha)
+    end
+
+    if button.powerBar then
+        local showPower = (kind == "party")
+        if showPower then
+            if type(_G.MSUF_SetBarValue) == "function" then
+                _G.MSUF_SetBarValue(button.powerBar, info.power or 0, false)
+            else
+                button.powerBar:SetValue(info.power or 0)
+            end
+            button.powerBar:Show()
+        else
+            button.powerBar:Hide()
+        end
+    end
+
+    if button.nameText then
+        button.nameText:SetText(text)
+        button.nameText:SetAlpha(alpha)
+    end
+    if button.statusText then
+        button.statusText:SetText(status)
+        button.statusText:SetShown(status ~= "")
+    end
+    if button.bg then
+        button.bg:SetColorTexture(0.05, 0.06, 0.09, 0.92)
+    end
+    if button.border and button.border.SetBackdropBorderColor then
+        button.border:SetBackdropBorderColor(0.10, 0.20, 0.42, preview and 0.55 or 0.35)
+    end
+    if button.unitLabel then
+        button.unitLabel:SetShown(preview)
+        if preview then button.unitLabel:SetText(tostring(index)) end
+    end
+end

--- a/MidnightSimpleUnitFrames/EditMode2/MSUF_EM2_Group.lua
+++ b/MidnightSimpleUnitFrames/EditMode2/MSUF_EM2_Group.lua
@@ -1,0 +1,160 @@
+local addonName, ns = ...
+
+local EM2 = _G.MSUF_EM2
+local GF = _G.MSUF_GroupFrames or ns.GroupFrames
+if not (EM2 and EM2.Registry and EM2.PopupFactory and GF) then return end
+
+local F = EM2.PopupFactory
+local Group = {}
+EM2.Group = Group
+
+local popup
+
+local function Conf(kind)
+    return GF.GetConfig and GF.GetConfig(kind)
+end
+
+local function Apply(kind)
+    local conf = Conf(kind)
+    if not conf or not popup then return end
+    conf.offsetX = tonumber(popup.xBox:GetText()) or conf.offsetX or 0
+    conf.offsetY = tonumber(popup.yBox:GetText()) or conf.offsetY or 0
+    conf.width = math.max(40, tonumber(popup.wBox:GetText()) or conf.width or 100)
+    conf.height = math.max(12, tonumber(popup.hBox:GetText()) or conf.height or 24)
+    conf.spacingX = tonumber(popup.sxBox:GetText()) or conf.spacingX or 0
+    conf.spacingY = tonumber(popup.syBox:GetText()) or conf.spacingY or 0
+    conf.columns = math.max(1, tonumber(popup.colsBox:GetText()) or conf.columns or 1)
+    conf.maxFrames = math.max(1, tonumber(popup.maxBox:GetText()) or conf.maxFrames or 5)
+    conf.showInEditMode = popup.editCB:GetChecked() and true or false
+    GF.Refresh(kind)
+    if EM2.Movers and EM2.Movers.SyncAll then EM2.Movers.SyncAll() end
+end
+
+local function Sync(kind)
+    local conf = Conf(kind)
+    if not conf or not popup then return end
+    popup.kind = kind
+    popup._titleFS:SetText(kind == "party" and "Party Group" or "Raid Group")
+    popup.xBox:SetText(tostring(conf.offsetX or 0))
+    popup.yBox:SetText(tostring(conf.offsetY or 0))
+    popup.wBox:SetText(tostring(conf.width or 100))
+    popup.hBox:SetText(tostring(conf.height or 24))
+    popup.sxBox:SetText(tostring(conf.spacingX or 0))
+    popup.syBox:SetText(tostring(conf.spacingY or 0))
+    popup.colsBox:SetText(tostring(conf.columns or 1))
+    popup.maxBox:SetText(tostring(conf.maxFrames or 5))
+    popup.editCB:SetChecked(conf.showInEditMode and true or false)
+end
+
+local function BuildPopup()
+    if popup then return popup end
+    popup = F.Panel("MSUF_EM2_GroupPopup", 380, 380, "Group")
+    local top = popup._contentTop
+
+    local c1, b1 = F.Card(popup, top, "Position & Size", -2, true)
+    local r1 = F.PairRow(popup, b1, c1, { label1 = "X:", label2 = "Y:", key1 = "xBox", key2 = "yBox", onChanged = function() Apply(popup.kind) end })
+    F.PairRow(popup, b1, c1, { label1 = "W:", label2 = "H:", key1 = "wBox", key2 = "hBox", anchorTo = r1, onChanged = function() Apply(popup.kind) end })
+    c1:RecalcHeight()
+
+    local c2, b2 = F.Card(popup, c1, "Layout", -6, true)
+    local r2 = F.PairRow(popup, b2, c2, { label1 = "Gap X:", label2 = "Gap Y:", key1 = "sxBox", key2 = "syBox", onChanged = function() Apply(popup.kind) end })
+    F.PairRow(popup, b2, c2, { label1 = "Cols:", label2 = "Max:", key1 = "colsBox", key2 = "maxBox", anchorTo = r2, onChanged = function() Apply(popup.kind) end })
+    c2:RecalcHeight()
+
+    local c3, b3 = F.Card(popup, c2, "Edit Mode", -6, true)
+    F.CheckRow(popup, b3, c3, { label = "Show in Edit Mode", cbKey = "editCB", onChanged = function() Apply(popup.kind) end })
+    c3:RecalcHeight()
+
+    local ok, cancel = F.FooterButtons(popup)
+    ok:SetScript("OnClick", function() Apply(popup.kind); popup:Hide() end)
+    cancel:SetScript("OnClick", function() popup:Hide() end)
+    popup:UpdateScrollHeight(360)
+    return popup
+end
+
+function Group.OpenPopup(kind)
+    BuildPopup()
+    Sync(kind)
+    popup:Show()
+end
+
+local function Register()
+    EM2.Registry.Register({
+        key = "group_party",
+        label = "Party Group",
+        order = 70,
+        popupType = "group",
+        canResize = true,
+        canNudge = true,
+        getFrame = function() return GF.GetContainer("party") end,
+        getConf = function() return Conf("party") end,
+        isEnabled = function() return true end,
+    })
+    EM2.Registry.Register({
+        key = "group_raid",
+        label = "Raid Group",
+        order = 71,
+        popupType = "group",
+        canResize = true,
+        canNudge = true,
+        getFrame = function() return GF.GetContainer("raid") end,
+        getConf = function() return Conf("raid") end,
+        isEnabled = function() return true end,
+    })
+end
+
+local previewFrame
+
+local function EnsurePreviewPopup()
+    if previewFrame then return previewFrame end
+    local f = CreateFrame("Frame", "MSUF_GroupPreviewPopup", UIParent, "BackdropTemplate")
+    f:SetSize(220, 100)
+    f:SetPoint("TOP", UIParent, "TOP", 0, -120)
+    f:SetFrameStrata("DIALOG")
+    f:SetBackdrop({ bgFile = "Interface\\Buttons\\WHITE8X8", edgeFile = "Interface\\Buttons\\WHITE8X8", edgeSize = 1 })
+    f:SetBackdropColor(0.03, 0.05, 0.12, 0.96)
+    f:SetBackdropBorderColor(0.10, 0.20, 0.45, 0.90)
+    f:Hide()
+
+    local title = f:CreateFontString(nil, "OVERLAY", "GameFontNormal")
+    title:SetPoint("TOP", f, "TOP", 0, -12)
+    title:SetText("Group Preview")
+    title:SetTextColor(1, 0.82, 0, 1)
+
+    local function MakeBtn(text, x, mode)
+        local b = CreateFrame("Button", nil, f, "UIPanelButtonTemplate")
+        b:SetSize(56, 22)
+        b:SetPoint("TOP", f, "TOP", x, -42)
+        b:SetText(text)
+        b:SetScript("OnClick", function()
+            local newMode = mode
+            if GF.GetPreviewMode and GF.GetPreviewMode() == mode then newMode = nil end
+            GF.SetPreviewMode(newMode)
+            f:Hide()
+            if EM2.HUD and EM2.HUD.RefreshControls then EM2.HUD.RefreshControls() end
+            if EM2.Movers and EM2.Movers.SyncAll then EM2.Movers.SyncAll() end
+        end)
+        return b
+    end
+
+    MakeBtn("Party", -58, "party")
+    MakeBtn("Raid", 0, "raid")
+    MakeBtn("Off", 58, nil)
+
+    previewFrame = f
+    return f
+end
+
+function Group.TogglePreviewPopup()
+    local f = EnsurePreviewPopup()
+    if f:IsShown() then f:Hide() else f:Show() end
+end
+
+function Group.GetPreviewMode()
+    return GF.GetPreviewMode and GF.GetPreviewMode() or nil
+end
+
+C_Timer.After(0, Register)
+
+function Group.ClosePopup() if popup then popup:Hide() end end
+function Group.IsPopupOpen() return popup and popup:IsShown() or false end

--- a/MidnightSimpleUnitFrames/EditMode2/MSUF_EM2_HUD.lua
+++ b/MidnightSimpleUnitFrames/EditMode2/MSUF_EM2_HUD.lua
@@ -13,7 +13,7 @@ local W8    = "Interface/Buttons/WHITE8X8"
 local floor, max, min = math.floor, math.max, math.min
 
 local hudFrame, row2Frame
-local previewBtn, auraBtn, snapToggle, cdmBtn, anchorBtn
+local previewBtn, groupBtn, auraBtn, snapToggle, cdmBtn, anchorBtn
 local undoBtn, redoBtn, cancelAllBtn, exitBtn
 local alphaFS, stepFS
 local helpBtn, tutorialPanel, tourState
@@ -661,6 +661,13 @@ local function EnsureHUD()
     SetTip(previewBtn, "Show placeholder data on unitframes\nwithout real units (target, focus, etc.)")
     r1[#r1+1] = previewBtn
 
+    groupBtn = MakeBtn(c1, "Groups", 58, BTN_H, 12, function()
+        if EM2.Group and EM2.Group.TogglePreviewPopup then EM2.Group.TogglePreviewPopup() end
+        HUD.RefreshControls()
+    end)
+    SetTip(groupBtn, "Open party / raid test previews\nfor Midnight group frames.")
+    r1[#r1+1] = groupBtn
+
     auraBtn = MakeBtn(c1, "Auras", 52, BTN_H, 12, function()
         local db = _G.MSUF_DB; if not db then return end
         local a2 = db.auras2; if not a2 then return end
@@ -800,6 +807,10 @@ function HUD.RefreshControls()
     if stepFS and EM2.Grid then stepFS:SetText("Grid " .. floor(EM2.Grid.GetGridStep()) .. "px") end
     if snapToggle and EM2.Snap then SetActive(snapToggle, EM2.Snap.IsEnabled()) end
     if previewBtn then SetActive(previewBtn, _G.MSUF_UnitPreviewActive and true or false) end
+    if groupBtn then
+        local mode = EM2.Group and EM2.Group.GetPreviewMode and EM2.Group.GetPreviewMode() or nil
+        SetActive(groupBtn, mode ~= nil)
+    end
     if cdmBtn then
         local db = _G.MSUF_DB
         SetActive(cdmBtn, db and db.general and db.general.anchorToCooldown and true or false)

--- a/MidnightSimpleUnitFrames/EditMode2/MSUF_EM2_Popups.lua
+++ b/MidnightSimpleUnitFrames/EditMode2/MSUF_EM2_Popups.lua
@@ -13,6 +13,7 @@ function Popups.CloseAll()
     if EM2.UnitPopup then EM2.UnitPopup.Close() end
     if EM2.CastPopup then EM2.CastPopup.Close() end
     if EM2.AuraPopup then EM2.AuraPopup.Close() end
+    if EM2.Group and EM2.Group.ClosePopup then EM2.Group.ClosePopup() end
     if EM2.State then EM2.State.SetPopupOpen(false) end
 end
 
@@ -51,6 +52,12 @@ function Popups.Open(key, anchorFrame)
         if key:sub(1, 5) == "aura_" then unit = key:sub(6) end
         local frame = cfg and cfg.getFrame and cfg.getFrame()
         if EM2.AuraPopup then EM2.AuraPopup.Open(unit, frame or anchorFrame) end
+    elseif pType == "group" then
+        local kind = (key == "group_raid") and "raid" or "party"
+        if EM2.Group and EM2.Group.OpenPopup then
+            EM2.Group.OpenPopup(kind)
+            if EM2.State then EM2.State.SetPopupOpen(true) end
+        end
     end
 end
 
@@ -58,5 +65,6 @@ function Popups.IsAnyOpen()
     return (EM2.UnitPopup and EM2.UnitPopup.IsOpen())
         or (EM2.CastPopup and EM2.CastPopup.IsOpen())
         or (EM2.AuraPopup and EM2.AuraPopup.IsOpen())
+        or (EM2.Group and EM2.Group.IsPopupOpen and EM2.Group.IsPopupOpen())
         or false
 end

--- a/MidnightSimpleUnitFrames/Features/MidnightSimpleUnitFrames_SlashMenu.lua
+++ b/MidnightSimpleUnitFrames/Features/MidnightSimpleUnitFrames_SlashMenu.lua
@@ -1961,6 +1961,10 @@ local function MSUF_EnsureColorsPanelBuilt() return MSUF_EnsureSubOptionsPanelBu
 local function MSUF_EnsureAuras2PanelBuilt() return MSUF_EnsureSubOptionsPanelBuilt("auras2") end
 local function MSUF_EnsureGameplayPanelBuilt() return MSUF_EnsureSubOptionsPanelBuilt("gameplay") end
 local function MSUF_EnsurePortraitsPanelBuilt() return MSUF_EnsureSubOptionsPanelBuilt("portraits") end
+local function MSUF_EnsureGroupPanelBuilt()
+local fn=_G and _G.MSUF_EnsureGroupOptionsPanelBuilt
+if type(fn)=="function"then return fn() end
+return nil end
 local function MSUF_EnsureModulesPanelBuilt() if _G.MSUF_ModulesMirrorPanel and _G.MSUF_ModulesMirrorPanel.__MSUF_ModulesBuilt then return _G.MSUF_ModulesMirrorPanel end
 local p=CreateFrame("Frame","MSUF_ModulesMirrorPanel",UIParent)
 _G.MSUF_ModulesMirrorPanel=p p.__MSUF_ModulesBuilt=true p.__MSUF_MirrorNoRestoreShow=true p:SetPoint("TOPLEFT",0,0)
@@ -2076,7 +2080,7 @@ local MIRROR_PAGES={home={title="Midnight Simple Unitframes (Version 1.9b3)",nav
 },opt_auras={title="MSUF Auras",build=MSUF_EnsureMainOptionsPanelBuilt,select=function() MSUF_SelectMainOptionsKey("auras") end
 },auras2={title="MSUF Auras 2.0",build=MSUF_EnsureAuras2PanelBuilt},opt_castbar={title="MSUF Castbar",build=MSUF_EnsureMainOptionsPanelBuilt,select=function() MSUF_SelectMainOptionsKey("castbar") end
 },opt_misc={title="MSUF Miscellaneous",build=MSUF_EnsureMainOptionsPanelBuilt,select=function() MSUF_SelectMainOptionsKey("misc") end
-},opt_colors={title="MSUF Colors",build=MSUF_EnsureColorsPanelBuilt},castbar={title="MSUF Castbar",build=MSUF_EnsureMainOptionsPanelBuilt,select=function(subkey) MSUF_SelectMainOptionsKey("castbar");
+},opt_groups={title="MSUF Group Frames",build=MSUF_EnsureGroupPanelBuilt},opt_colors={title="MSUF Colors",build=MSUF_EnsureColorsPanelBuilt},castbar={title="MSUF Castbar",build=MSUF_EnsureMainOptionsPanelBuilt,select=function(subkey) MSUF_SelectMainOptionsKey("castbar");
 if subkey and subkey~=""then MSUF_SelectCastbarSubPage(subkey)
 end
 end
@@ -2415,16 +2419,16 @@ home={0,0},
 uf_player={1,0},uf_target={2,0},uf_targettarget={3,0},
 uf_focus={4,0},uf_boss={5,0},uf_pet={6,0},
 opt_bars={7,0},opt_fonts={0,1},auras2={1,1},
-opt_castbar={2,1},opt_misc={3,1},opt_colors={4,1},
-opt_portraits={5,1},classpower={6,1},gameplay={7,1},
-modules={0,2},profiles={1,2},
+opt_castbar={2,1},opt_misc={3,1},opt_groups={4,1},opt_colors={5,1},
+opt_portraits={6,1},classpower={7,1},gameplay={0,2},
+modules={1,2},profiles={2,2},
 }
 local MSUF_NAV_ICON_COLORS={
 home={0.30,0.60,1.00},
 uf_player={0.40,0.78,0.98},uf_target={0.40,0.78,0.98},uf_targettarget={0.40,0.78,0.98},
 uf_focus={0.40,0.78,0.98},uf_boss={0.40,0.78,0.98},uf_pet={0.40,0.78,0.98},
 opt_bars={0.88,0.74,0.36},opt_fonts={0.88,0.74,0.36},auras2={0.88,0.74,0.36},
-opt_castbar={0.88,0.74,0.36},opt_misc={0.88,0.74,0.36},opt_colors={0.88,0.74,0.36},
+opt_castbar={0.88,0.74,0.36},opt_misc={0.88,0.74,0.36},opt_groups={0.88,0.74,0.36},opt_colors={0.88,0.74,0.36},
 opt_portraits={0.88,0.74,0.36},
 classpower={0.35,0.82,0.50},gameplay={0.72,0.50,0.92},
 modules={0.40,0.80,0.75},profiles={0.90,0.62,0.30},
@@ -2475,7 +2479,7 @@ navParent._msufNavStripe=stripe end
 local function MakeButton(label,w,onClick,isHeader,isChild) local b=UI_Button(navParent,tostring(label or""),w,btnH,"TOPLEFT",navParent,"TOPLEFT",0,0,onClick)
 MSUF_LeftJustifyButtonText(b,isHeader and 18 or(isChild and 22 or 24))
 MSUF_SkinNavButton(b,isHeader,isChild) return b end
-local NAV={{type="leaf",key="home",label="Dashboard"},{type="header",id="unitframes",label="Unit Frames",defaultOpen=true,children={{key="uf_player",label="Player"},{key="uf_target",label="Target"},{key="uf_targettarget",label="Target of Target"},{key="uf_focus",label="Focus"},{key="uf_boss",label="Boss Frames"},{key="uf_pet",label="Pet"},}},{type="header",id="options",label="Options",defaultOpen=true,children={{key="opt_bars",label="Bars"},{key="opt_fonts",label="Fonts"},{key="auras2",label="Auras 2.0"},{key="opt_castbar",label="Castbar"},{key="opt_portraits",label="Portraits"},{key="opt_colors",label="Colors"},{key="opt_misc",label="Miscellaneous"},}},{type="leaf",key="classpower",label="Class Resources"},{type="leaf",key="gameplay",label="Gameplay"},{type="header",id="modules",label="Modules",defaultOpen=false,children={{key="modules",label="Style"},}},{type="leaf",key="profiles",label="Profiles"},}
+local NAV={{type="leaf",key="home",label="Dashboard"},{type="header",id="unitframes",label="Unit Frames",defaultOpen=true,children={{key="uf_player",label="Player"},{key="uf_target",label="Target"},{key="uf_targettarget",label="Target of Target"},{key="uf_focus",label="Focus"},{key="uf_boss",label="Boss Frames"},{key="uf_pet",label="Pet"},}},{type="header",id="options",label="Options",defaultOpen=true,children={{key="opt_bars",label="Bars"},{key="opt_fonts",label="Fonts"},{key="auras2",label="Auras 2.0"},{key="opt_castbar",label="Castbar"},{key="opt_groups",label="Group Frames"},{key="opt_portraits",label="Portraits"},{key="opt_colors",label="Colors"},{key="opt_misc",label="Miscellaneous"},}},{type="leaf",key="classpower",label="Class Resources"},{type="leaf",key="gameplay",label="Gameplay"},{type="header",id="modules",label="Modules",defaultOpen=false,children={{key="modules",label="Style"},}},{type="leaf",key="profiles",label="Profiles"},}
 local headerLabels={}
 for _,node in ipairs(NAV)
 do if node.type=="header"then headerLabels[node.id]=node.label end

--- a/MidnightSimpleUnitFrames/Foundation/MSUF_Defaults.lua
+++ b/MidnightSimpleUnitFrames/Foundation/MSUF_Defaults.lua
@@ -1014,6 +1014,38 @@ for _, key in ipairs({"player","target","focus","targettarget","pet","boss"}) do
     end
     if conf.raidMarkerSize == nil then conf.raidMarkerSize = 14 end
 end
+if MSUF_DB.groupFrames == nil then
+    MSUF_DB.groupFrames = {}
+end
+for kind, defaults in pairs({
+    party = {
+        enabled = true, showInEditMode = true, point = "TOPLEFT", relPoint = "TOPLEFT",
+        offsetX = 420, offsetY = -260, width = 132, height = 28,
+        spacingX = 0, spacingY = 4, columns = 1, maxFrames = 5,
+        barOverride = false, barTexture = nil,
+        fontOverride = false, fontPath = nil, nameFontSize = 11,
+        colorOverride = false, useClassColors = true, darkMode = false,
+        colorR = 0.18, colorG = 0.55, colorB = 0.88,
+    },
+    raid = {
+        enabled = true, showInEditMode = true, point = "TOPLEFT", relPoint = "TOPLEFT",
+        offsetX = 420, offsetY = -24, width = 92, height = 22,
+        spacingX = 4, spacingY = 4, columns = 5, maxFrames = 40,
+        barOverride = false, barTexture = nil,
+        fontOverride = false, fontPath = nil, nameFontSize = 10,
+        colorOverride = false, useClassColors = true, darkMode = false,
+        colorR = 0.18, colorG = 0.55, colorB = 0.88,
+    },
+}) do
+    local conf = MSUF_DB.groupFrames[kind]
+    if type(conf) ~= "table" then
+        conf = {}
+        MSUF_DB.groupFrames[kind] = conf
+    end
+    for k, v in pairs(defaults) do
+        if conf[k] == nil then conf[k] = v end
+    end
+end
 if MSUF_DB.bars == nil then
         MSUF_DB.bars = {}
     end

--- a/MidnightSimpleUnitFrames/MidnightSimpleUnitFrames.lua
+++ b/MidnightSimpleUnitFrames/MidnightSimpleUnitFrames.lua
@@ -5993,6 +5993,9 @@ if type(_G.MSUF_ApplyAllSettings_Immediate) == "function" then
 else
     ApplyAllSettings()
 end
+if _G and _G.MSUF_GroupFrames and type(_G.MSUF_GroupFrames.TryEnable) == "function" then
+    _G.MSUF_GroupFrames.TryEnable()
+end
 -- P0: Pre-resolve split-module function refs for UpdateSimpleUnitFrame.
 -- After PLAYER_LOGIN all Core/ files have loaded. Eliminates 3 branches
 -- + 3 _G hash lookups per frame update (300-1500 branches/sec in combat).

--- a/MidnightSimpleUnitFrames/MidnightSimpleUnitFrames.toc
+++ b/MidnightSimpleUnitFrames/MidnightSimpleUnitFrames.toc
@@ -150,6 +150,10 @@ ClassPower\Core\MSUF_CP_AltMana.lua
 ClassPower\Core\MSUF_CP_Layout.lua
 ClassPower\MSUF_CP_Controller.lua
 Core\MSUF_ClassPower.lua
+Core\MSUF_GroupRoster.lua
+Core\MSUF_GroupUpdate.lua
+Core\MSUF_GroupFrames.lua
+EditMode2\MSUF_EM2_Group.lua
 
 # ═══════════════════════════════════════════════════════════════
 # OPTIONS
@@ -165,6 +169,7 @@ Options\MSUF_Options_ClassPower_QuickSetup.lua
 Options\MSUF_Options_Player.lua
 Options\MSUF_Options_Auras.lua
 Options\MSUF_Options_Fonts.lua
+Options\MSUF_Options_Group.lua
 Options\MSUF_Options_Misc.lua
 Options\MSUF_Options_Portraits.lua
 Options\MSUF_Options_Gameplay.lua

--- a/MidnightSimpleUnitFrames/Options/MSUF_Options_Group.lua
+++ b/MidnightSimpleUnitFrames/Options/MSUF_Options_Group.lua
@@ -1,0 +1,161 @@
+local addonName, ns = ...
+
+local function GetGF()
+    return _G.MSUF_GroupFrames or (ns and ns.GroupFrames)
+end
+
+local panel
+
+local function DB(kind)
+    local gf = GetGF()
+    return gf and gf.GetConfig and gf.GetConfig(kind)
+end
+
+local function Apply(kind)
+    local gf = GetGF()
+    if not gf then return end
+    gf.ApplyStyle(kind)
+    gf.Refresh(kind)
+    if _G.MSUF_EM2 and _G.MSUF_EM2.Movers and _G.MSUF_EM2.Movers.SyncAll then
+        _G.MSUF_EM2.Movers.SyncAll()
+    end
+end
+
+local function MakeCheckbox(parent, text, x, y, getter, setter)
+    local cb = CreateFrame("CheckButton", nil, parent, "UICheckButtonTemplate")
+    cb:SetPoint("TOPLEFT", parent, "TOPLEFT", x, y)
+    local label = cb.Text or cb.text or _G[(cb:GetName() or "") .. "Text"]
+    if label and label.SetText then label:SetText(text) end
+    cb:SetScript("OnClick", function(self)
+        setter(self:GetChecked() and true or false)
+    end)
+    cb.Refresh = function()
+        cb:SetChecked(getter() and true or false)
+    end
+    return cb
+end
+
+local function MakeEdit(parent, label, x, y, width, getter, setter)
+    local fs = parent:CreateFontString(nil, "OVERLAY", "GameFontHighlightSmall")
+    fs:SetPoint("TOPLEFT", parent, "TOPLEFT", x, y)
+    fs:SetText(label)
+
+    local eb = CreateFrame("EditBox", nil, parent, "InputBoxTemplate")
+    eb:SetSize(width or 54, 20)
+    eb:SetPoint("LEFT", fs, "RIGHT", 8, 0)
+    eb:SetAutoFocus(false)
+    eb:SetScript("OnEnterPressed", function(self)
+        setter(self:GetText())
+        self:ClearFocus()
+    end)
+    eb:SetScript("OnEditFocusLost", function(self)
+        setter(self:GetText())
+    end)
+    eb.Refresh = function()
+        eb:SetText(tostring(getter() or ""))
+    end
+    return eb
+end
+
+local function BuildSection(parent, kind, title, x)
+    local host = CreateFrame("Frame", nil, parent, "BackdropTemplate")
+    host:SetSize(360, 270)
+    host:SetPoint("TOPLEFT", parent, "TOPLEFT", x, -54)
+    host:SetBackdrop({ bgFile = "Interface\\Buttons\\WHITE8X8", edgeFile = "Interface\\Buttons\\WHITE8X8", edgeSize = 1 })
+    host:SetBackdropColor(0.03, 0.05, 0.12, 0.92)
+    host:SetBackdropBorderColor(0.10, 0.20, 0.45, 0.55)
+
+    local hdr = host:CreateFontString(nil, "OVERLAY", "GameFontNormal")
+    hdr:SetPoint("TOPLEFT", host, "TOPLEFT", 12, -12)
+    hdr:SetText(title)
+    hdr:SetTextColor(1, 0.82, 0, 1)
+
+    local conf = function() return DB(kind) end
+    local refreshers = {}
+
+    refreshers[#refreshers + 1] = MakeCheckbox(host, "Enabled", 12, -38, function() return conf().enabled ~= false end, function(v) conf().enabled = v; Apply(kind) end)
+    refreshers[#refreshers + 1] = MakeCheckbox(host, "Show in Edit Mode", 120, -38, function() return conf().showInEditMode ~= false end, function(v) conf().showInEditMode = v; Apply(kind) end)
+    refreshers[#refreshers + 1] = MakeCheckbox(host, "Bar Override", 12, -68, function() return conf().barOverride == true end, function(v) conf().barOverride = v; Apply(kind) end)
+    refreshers[#refreshers + 1] = MakeCheckbox(host, "Font Override", 120, -68, function() return conf().fontOverride == true end, function(v) conf().fontOverride = v; Apply(kind) end)
+    refreshers[#refreshers + 1] = MakeCheckbox(host, "Color Override", 240, -68, function() return conf().colorOverride == true end, function(v) conf().colorOverride = v; Apply(kind) end)
+    refreshers[#refreshers + 1] = MakeCheckbox(host, "Use Class Colors", 12, -98, function() return conf().useClassColors ~= false end, function(v) conf().useClassColors = v; Apply(kind) end)
+    refreshers[#refreshers + 1] = MakeCheckbox(host, "Dark Mode", 160, -98, function() return conf().darkMode == true end, function(v) conf().darkMode = v; Apply(kind) end)
+
+    refreshers[#refreshers + 1] = MakeEdit(host, "Width", 12, -132, 44, function() return conf().width end, function(v) conf().width = tonumber(v) or conf().width; Apply(kind) end)
+    refreshers[#refreshers + 1] = MakeEdit(host, "Height", 118, -132, 44, function() return conf().height end, function(v) conf().height = tonumber(v) or conf().height; Apply(kind) end)
+    refreshers[#refreshers + 1] = MakeEdit(host, "Cols", 228, -132, 44, function() return conf().columns end, function(v) conf().columns = tonumber(v) or conf().columns; Apply(kind) end)
+
+    refreshers[#refreshers + 1] = MakeEdit(host, "Gap X", 12, -164, 44, function() return conf().spacingX end, function(v) conf().spacingX = tonumber(v) or conf().spacingX; Apply(kind) end)
+    refreshers[#refreshers + 1] = MakeEdit(host, "Gap Y", 118, -164, 44, function() return conf().spacingY end, function(v) conf().spacingY = tonumber(v) or conf().spacingY; Apply(kind) end)
+    refreshers[#refreshers + 1] = MakeEdit(host, "Max", 228, -164, 44, function() return conf().maxFrames end, function(v) conf().maxFrames = tonumber(v) or conf().maxFrames; Apply(kind) end)
+
+    refreshers[#refreshers + 1] = MakeEdit(host, "Font Size", 12, -196, 44, function() return conf().nameFontSize or 11 end, function(v) conf().nameFontSize = tonumber(v) or conf().nameFontSize; Apply(kind) end)
+    refreshers[#refreshers + 1] = MakeEdit(host, "Color R", 118, -196, 44, function() return conf().colorR or 0.18 end, function(v) conf().colorR = tonumber(v) or conf().colorR; Apply(kind) end)
+    refreshers[#refreshers + 1] = MakeEdit(host, "Color G", 228, -196, 44, function() return conf().colorG or 0.55 end, function(v) conf().colorG = tonumber(v) or conf().colorG; Apply(kind) end)
+    refreshers[#refreshers + 1] = MakeEdit(host, "Color B", 12, -228, 44, function() return conf().colorB or 0.88 end, function(v) conf().colorB = tonumber(v) or conf().colorB; Apply(kind) end)
+
+    function host:Refresh()
+        for i = 1, #refreshers do
+            if refreshers[i] and refreshers[i].Refresh then refreshers[i]:Refresh() end
+        end
+    end
+
+    return host
+end
+
+function ns.MSUF_EnsureGroupOptionsPanelBuilt()
+    if panel then
+        if panel.Refresh then panel:Refresh() end
+        return panel
+    end
+
+    panel = CreateFrame("Frame", "MSUF_GroupOptionsPanel", UIParent, "BackdropTemplate")
+    panel:SetAllPoints()
+    panel.__MSUF_MirrorNoRestoreShow = true
+
+    local title = panel:CreateFontString(nil, "OVERLAY", "GameFontNormalLarge")
+    title:SetPoint("TOPLEFT", panel, "TOPLEFT", 16, -16)
+    title:SetText("Group Frames")
+    title:SetTextColor(1, 0.82, 0, 1)
+
+    local sub = panel:CreateFontString(nil, "OVERLAY", "GameFontHighlightSmall")
+    sub:SetPoint("TOPLEFT", title, "BOTTOMLEFT", 0, -6)
+    sub:SetText("Party and Raid group frames with Midnight-native edit-mode hooks.")
+
+    panel.partySection = BuildSection(panel, "party", "Party", 16)
+    panel.raidSection = BuildSection(panel, "raid", "Raid", 400)
+
+    local preview = CreateFrame("Button", nil, panel, "UIPanelButtonTemplate")
+    preview:SetSize(140, 24)
+    preview:SetPoint("TOPLEFT", panel, "TOPLEFT", 16, -340)
+    preview:SetText("Toggle Party Preview")
+    preview:SetScript("OnClick", function()
+        local gf = GetGF()
+        if not gf then return end
+        local nextMode = (gf.GetPreviewMode and gf.GetPreviewMode() == "party") and nil or "party"
+        gf.SetPreviewMode(nextMode)
+        panel:Refresh()
+    end)
+
+    local previewRaid = CreateFrame("Button", nil, panel, "UIPanelButtonTemplate")
+    previewRaid:SetSize(140, 24)
+    previewRaid:SetPoint("LEFT", preview, "RIGHT", 8, 0)
+    previewRaid:SetText("Toggle Raid Preview")
+    previewRaid:SetScript("OnClick", function()
+        local gf = GetGF()
+        if not gf then return end
+        local nextMode = (gf.GetPreviewMode and gf.GetPreviewMode() == "raid") and nil or "raid"
+        gf.SetPreviewMode(nextMode)
+        panel:Refresh()
+    end)
+
+    function panel:Refresh()
+        if self.partySection and self.partySection.Refresh then self.partySection:Refresh() end
+        if self.raidSection and self.raidSection.Refresh then self.raidSection:Refresh() end
+    end
+
+    panel:Refresh()
+    return panel
+end
+
+_G.MSUF_EnsureGroupOptionsPanelBuilt = ns.MSUF_EnsureGroupOptionsPanelBuilt


### PR DESCRIPTION
### Motivation
- Provide a Phase‑1 foundation for MSUF native group frames (party + raid) with Grid2‑like features while remaining secret‑safe and integrated into existing MSUF systems. 
- Allow editing and previewing group frames from MSUF Edit Mode and the slash‑menu, and expose per‑group overrides for bars/fonts/colors. 

### Description
- New core modules implement roster tracking, unit event routing, preview mode, and an update/style layer: `Core/MSUF_GroupRoster.lua`, `Core/MSUF_GroupUpdate.lua`, and `Core/MSUF_GroupFrames.lua`. 
- Edit Mode integration: add an EM2 group popup and preview launcher and register party/raid mover entries via `EditMode2/MSUF_EM2_Group.lua`, plus HUD and popup routing changes in `EditMode2/MSUF_EM2_HUD.lua` and `EditMode2/MSUF_EM2_Popups.lua`. 
- Options and UX: add a Group Frames options panel and mirror entry in the slash menu via `Options/MSUF_Options_Group.lua` and edits to `Features/MidnightSimpleUnitFrames_SlashMenu.lua`. 
- Defaults and load order: seed `MSUF_DB.groupFrames` defaults in `Foundation/MSUF_Defaults.lua` and add new files to the TOC and main init hook (`MidnightSimpleUnitFrames.toc`, `MidnightSimpleUnitFrames.lua`) so group frames initialize after core. 
- Live refresh hooks: hook into existing font/color/settings update paths (`MSUF_UpdateAllFonts`, `MSUF_RefreshAllIdentityColors`, `ApplyAllSettings`) to reapply group styles and refresh layout when relevant globals change. 

### Testing
- Ran `git diff --check` to ensure no whitespace/index issues (passed). 
- Verified presence and TOC registration of new modules with a Python assertion script that checks files exist and are referenced in `MidnightSimpleUnitFrames.toc` (passed). 
- Verified new group files contain no trailing whitespace with a Python checker (passed). 
- Checked that changes compile into the TOC ordering and basic runtime hooks by running spot checks of modified files (no runtime Lua interpreter available in the environment, so no full syntax/VM run was performed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c14ffd2bf48330929eb49035c0be06)