### PR TITLE
Fix: Make party frame honor max columns

### DIFF
--- a/MidnightSimpleUnitFrames/GroupFrames/MSUF_GroupFrames_DB.lua
+++ b/MidnightSimpleUnitFrames/GroupFrames/MSUF_GroupFrames_DB.lua
@@ -1037,10 +1037,9 @@ end
 function GF.GetVisibleLayoutCount(kind, count, conf)
     count = math_floor((tonumber(count) or 0) + 0.5)
     if count < 1 then return count end
-    if not IsRaidLikeKind(kind) then return count end
 
     conf = conf or (GF.GetConf and GF.GetConf(kind)) or {}
-    if conf and conf.preserveRaidGroups == true then
+    if IsRaidLikeKind(kind) and conf and conf.preserveRaidGroups == true then
         local groups = math_floor((tonumber(conf.maxColumns) or 8) + 0.5)
         if groups < 1 then groups = 1 elseif groups > 8 then groups = 8 end
         return math_min(count, groups * 5)
@@ -1048,8 +1047,10 @@ function GF.GetVisibleLayoutCount(kind, count, conf)
 
     local upc = math_floor((tonumber(conf and conf.unitsPerColumn) or 5) + 0.5)
     if upc < 1 then upc = 1 elseif upc > 40 then upc = 40 end
-    local columns = math_floor((tonumber(conf and conf.maxColumns) or 8) + 0.5)
-    if columns < 1 then columns = 1 elseif columns > 40 then columns = 40 end
+    local maxDefault = IsRaidLikeKind(kind) and 8 or 1
+    local columnCap = IsRaidLikeKind(kind) and 40 or 8
+    local columns = math_floor((tonumber(conf and conf.maxColumns) or maxDefault) + 0.5)
+    if columns < 1 then columns = 1 elseif columns > columnCap then columns = columnCap end
     return math_min(count, upc * columns)
 end
 

--- a/MidnightSimpleUnitFrames/UnitFrames/Engine/Group/MSUF_UF_Group_Headers.lua
+++ b/MidnightSimpleUnitFrames/UnitFrames/Engine/Group/MSUF_UF_Group_Headers.lua
@@ -532,10 +532,9 @@ local function RaidGroupingOrder(conf)
 end
 
 local function RequiredHeaderColumns(kind, conf, count)
-  if kind == "party" then return 1 end
   count = floor((tonumber(count) or 0) + 0.5)
   if count < 1 then return 1 end
-  if conf and conf.preserveRaidGroups == true then
+  if kind ~= "party" and conf and conf.preserveRaidGroups == true then
     local groups = floor(((count + 4) / 5))
     local maxGroups = PreservedRaidGroupLimit(conf) or 8
     if groups < 1 then groups = 1 elseif groups > 8 then groups = 8 end
@@ -548,9 +547,11 @@ local function RequiredHeaderColumns(kind, conf, count)
     return columns
   end
   local upc = ClampInt(conf and conf.unitsPerColumn, 5, 1, 40)
-  local maxColumns = ClampInt(conf and conf.maxColumns, 8, 1, 40)
+  local maxDefault = kind == "party" and 1 or 8
+  local columnCap = kind == "party" and 8 or 40
+  local maxColumns = ClampInt(conf and conf.maxColumns, maxDefault, 1, columnCap)
   local columns = floor(((count + upc - 1) / upc))
-  if columns < 1 then columns = 1 elseif columns > 40 then columns = 40 end
+  if columns < 1 then columns = 1 elseif columns > columnCap then columns = columnCap end
   if columns > maxColumns then columns = maxColumns end
   return columns
 end


### PR DESCRIPTION
Party Geometry and Edit Mode preview already used unitsPerColumn x maxColumns, but live SecureGroupHeader forced one column, so setups like 1x5 only showed a single member.